### PR TITLE
Bugfix of loading persistence data with selected whitelist or broadca…

### DIFF
--- a/CSK_Module_MultiTCPIPServer/scripts/Communication/MultiTCPIPServer/MultiTCPIPServer_Controller.lua
+++ b/CSK_Module_MultiTCPIPServer/scripts/Communication/MultiTCPIPServer/MultiTCPIPServer_Controller.lua
@@ -890,8 +890,11 @@ local function updateProcessingParameters()
   Script.notifyEvent('MultiTCPIPServer_OnNewProcessingParameter', selectedInstance, 'clientBroadcasts', json.encode(multiTCPIPServer_Instances[selectedInstance].parameters.clientBroadcasts.names))
   Script.notifyEvent('MultiTCPIPServer_OnNewProcessingParameter', selectedInstance, 'onReceivedDataEventName', multiTCPIPServer_Instances[selectedInstance].parameters.onReceivedDataEventName)
   Script.notifyEvent('MultiTCPIPServer_OnNewProcessingParameter', selectedInstance, 'sendDataFunctionName', multiTCPIPServer_Instances[selectedInstance].parameters.sendDataFunctionName)
-
   Script.notifyEvent('MultiTCPIPServer_OnNewProcessingParameter', selectedInstance, 'listenState', multiTCPIPServer_Instances[selectedInstance].parameters.listenState)
+  selectedTab = 0 
+  selectedClientWhitelist = ''
+  selectedClientBroadcast = ''
+  
 end
 
 local function getStatusModuleActive()


### PR DESCRIPTION


# Version 2.0.0

## Bugfix

### Bugfix of loading persistence data with selected whitelist or broadcast that does not exist in loaded data

## Following tasks were checked

- [v] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [v] All functions/events/parameters are documented within the manifest documentation
- [v] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [v] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [v] Internal LUA code documentation exists for variables and non served functions
- [v] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [v] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [v] Module supports user management based on 'CSK_Module_UserManagement'
- [v] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [v] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [v] Meaningful IDs used for UI elements
- [v] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [v] README.md is up to date (incl. info of device + firmware the module was tested with)
- [v] CHANGELOG.md is up to date
